### PR TITLE
remove empty link that's breaking Site Source link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,7 +34,6 @@
         {{ content }}
         <div class="footer">
             <ul>
-                <li><a href="</a></li>
                 <li><a href="https://github.com/appdesign1987/blog-src">Site Source</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Looks like there's a missing "> that's breaking the syntax and causing "Site Source"'s URL to be invalid. Since you're not using the first URL, may as well remove it?